### PR TITLE
Fix xref

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,21 @@
+%% == Erlang Compiler ==
+
 {erl_opts, [debug_info]}.
+
+%% == Dependencies ==
+
 {deps, []}.
+
+%% == Xref ==
+
+{xref_checks, [
+    undefined_function_calls,
+    undefined_functions,
+    locals_not_used,
+    deprecated_function_calls,
+    deprecated_funcqtions
+]}.
+
+%% == Plugins ==
 
 {plugins, [rebar3_hex]}.


### PR DESCRIPTION
Fix `xref` warnings:
```
===> src/ppplib.erl:14: Warning: ppplib:frame_decode/1 is unused export (Xref)
src/ppplib.erl:16: Warning: ppplib:frame_encode/1 is unused export (Xref)
src/ppplib.erl:18: Warning: ppplib:hdlc_crc16/1 is unused export (Xref)
src/ppplib.erl:20: Warning: ppplib:hdlc_decapsulate/1 is unused export (Xref)
src/ppplib.erl:22: Warning: ppplib:hdlc_encapsulate/1 is unused export (Xref)
src/ppplib.erl:24: Warning: ppplib:oeframe_decode/1 is unused export (Xref)
src/ppplib.erl:26: Warning: ppplib:oeframe_encode/1 is unused export (Xref)
```