### PR TITLE
Remove non use var

### DIFF
--- a/src/ppp_frame.erl
+++ b/src/ppp_frame.erl
@@ -208,7 +208,7 @@ decode(<<?PPP_CHAP:16/integer, Code:8/integer, Id:8/integer, Length:16/integer, 
     <<Data:DataLen/bytes, _Pad/binary>> = Rest,
     decode_chap(Data, Id, Code);
 
-decode(<<Protocol:16/integer, Code:8/integer, Id:8/integer, Length:16/integer, Data/binary>>)
+decode(<<Protocol:16/integer, Code:8/integer, Id:8/integer, _:16/integer, Data/binary>>)
   when Protocol >= 16#8000 ->
     {Protocol, cp_code(Code), Id, Data}.
 


### PR DESCRIPTION
Fix warning:
`src/ppplib_frame.erl:209: Warning: variable 'Length' is unused`