### PR TITLE
Fix hex.yaml

### DIFF
--- a/.github/workflows/hex.yaml
+++ b/.github/workflows/hex.yaml
@@ -21,5 +21,10 @@ jobs:
       env:
         HEX_API_KEY: ${{ secrets.HEX_API_KEY }}
       run: |
+           git init
+           git remote add origin https://github.com/travelping/ppplib.git
+           git fetch
+           git add .
+           git checkout $( git tag | tail -1 )
            rebar3 edoc
            rebar3 hex publish -r hexpm --yes


### PR DESCRIPTION
By some reason(`===> Getting log of git repo failed in /__w/ppplib/ppplib. Falling back to version 0.0.0`), the previous implementation was try push tag `0.0.0` into `hex.pm`. The current implementation will use git latest tag.